### PR TITLE
feat(ms-customers): Cambiar JWT principal de email a UUID

### DIFF
--- a/ms-customers/src/main/java/com/bankcore/customers/repository/UserRepository.java
+++ b/ms-customers/src/main/java/com/bankcore/customers/repository/UserRepository.java
@@ -35,12 +35,12 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     boolean existsByEmail(String email);
 
     /**
-     * Retrieves a user entity from the database using their email address.
+     * Retrieves a user entity from the database using their id.
      *
-     * @param email The email address to search for.
+     * @param id The id to search for.
      * @return An {@link Optional} containing the {@link UserEntity} if found,
-     * or {@link Optional#empty()} if no user matches the provided email.
+     * or {@link Optional#empty()} if no user matches the provided id.
      */
-    Optional<UserEntity> findByEmail(String email);
+    Optional<UserEntity> findById(UUID id);
 
 }

--- a/ms-customers/src/main/java/com/bankcore/customers/service/UserManagement.java
+++ b/ms-customers/src/main/java/com/bankcore/customers/service/UserManagement.java
@@ -45,10 +45,10 @@ public interface UserManagement {
      * data is properly mapped to a response DTO.
      * </p>
      *
-     * @param email The unique email address of the user.
+     * @param id The unique id of the user.
      * @return A {@link UserProfileResponse} object containing the user's profile details.
-     * @throws UserProfileNotFoundException If no user exists with the specified email.
-     * @throws IllegalArgumentException      If the email parameter is invalid (null or blank).
+     * @throws UserProfileNotFoundException If no user exists with the specified id.
+     * @throws IllegalArgumentException     If the id parameter is invalid (null or blank).
      */
-    UserProfileResponse getCurrentUserProfile(String email);
+    UserProfileResponse getCurrentUserProfile(String id);
 }

--- a/ms-customers/src/main/java/com/bankcore/customers/service/UserManagementImpl.java
+++ b/ms-customers/src/main/java/com/bankcore/customers/service/UserManagementImpl.java
@@ -15,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 /**
  * Default implementation of {@link UserManagement}.
  * <p>
@@ -104,14 +106,14 @@ public class UserManagementImpl implements UserManagement {
     }
 
     /**
-     * Retrieves the profile data for a specific user based on their email.
+     * Retrieves the profile data for a specific user based on their id.
      * <p>
      * This method performs a read-only transaction to fetch the user entity.
      * It validates the input and ensures that if the user does not exist in the
      * persistence layer, a specific business exception is thrown.
      * </p>
      *
-     * @param email The email of the authenticated user to retrieve.
+     * @param id The id of the authenticated user to retrieve.
      * @return A {@link UserProfileResponse} containing the mapped profile data.
      * @throws IllegalArgumentException      If the provided email is null or empty.
      * @throws UserProfileNotFoundException If no user is found with the given email.
@@ -120,15 +122,15 @@ public class UserManagementImpl implements UserManagement {
      */
     @Override
     @Transactional(readOnly = true)
-    public UserProfileResponse getCurrentUserProfile(String email) {
+    public UserProfileResponse getCurrentUserProfile(String id) {
 
-        if (email == null || email.isBlank()) {
-            throw new IllegalArgumentException("Email must not be null or blank");
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Id must not be null or blank");
         }
 
-        UserEntity user = userRepository.findByEmail(email)
+        UserEntity user = userRepository.findById(UUID.fromString(id))
                 .orElseThrow(() ->
-                        new UserProfileNotFoundException("Authenticated user not found: " + email));
+                        new UserProfileNotFoundException("Authenticated user not found: " + id));
 
 
         return userMapper.toUserProfileResponse(user);

--- a/ms-customers/src/test/java/com/bankcore/customers/DataProvider.java
+++ b/ms-customers/src/test/java/com/bankcore/customers/DataProvider.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 public class DataProvider {
 
     public static final String EMAIL = "juan@test.com";
+    public static final String UUID = "9e85d91b-3b89-4404-b0ca-12a4b0533510";
     public static final String CUSTOMER_ROLE = "CUSTOMER";
 
     public static UserEntity createMockUser(){

--- a/ms-customers/src/test/java/com/bankcore/customers/controller/ProfileControllerIntegrationTest.java
+++ b/ms-customers/src/test/java/com/bankcore/customers/controller/ProfileControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -34,19 +35,20 @@ public class ProfileControllerIntegrationTest extends AbstractIntegrationTest {
     @Autowired
     private UserManagementImpl userManagement;
 
+    private UserEntity savedUser;
+
     @BeforeEach
     public void init() {
         UserEntity user = DataProvider.createMockUser();
-        userRepository.save(user);
+        savedUser = userRepository.save(user);
     }
 
     @Test
-    @WithMockUser(
-            username = DataProvider.EMAIL,
-            roles = DataProvider.CUSTOMER_ROLE
-    )
     void shouldReturnProfileWhenAuthorized() throws Exception {
-        mockMvc.perform(get("/api/customers/me"))
+        mockMvc.perform(get("/api/customers/me")
+                        .with(user(savedUser.getId().toString())
+                                .roles(DataProvider.CUSTOMER_ROLE))
+                )
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -64,20 +66,20 @@ public class ProfileControllerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "example@mail.com", roles = DataProvider.CUSTOMER_ROLE)
+    @WithMockUser(username = DataProvider.UUID, roles = DataProvider.CUSTOMER_ROLE)
     void shouldReturn404WhenUserNotFound() throws Exception {
-
         mockMvc.perform(get("/api/customers/me"))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value(HttpStatus.NOT_FOUND.value()))
                 .andExpect(jsonPath("$.name").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
-                .andExpect(jsonPath("$.description").exists());;
+                .andExpect(jsonPath("$.description").exists());
+        ;
     }
 
     @Test
-    @WithMockUser(username = DataProvider.EMAIL, roles = "ADMIN")
+    @WithMockUser(username = DataProvider.UUID, roles = "ADMIN")
     void shouldReturn403WhenWrongRole() throws Exception {
 
         mockMvc.perform(get("/api/customers/me"))
@@ -86,7 +88,8 @@ public class ProfileControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.code").value(HttpStatus.FORBIDDEN.value()))
                 .andExpect(jsonPath("$.name").value(HttpStatus.FORBIDDEN.getReasonPhrase()))
-                .andExpect(jsonPath("$.description").exists());;
+                .andExpect(jsonPath("$.description").exists());
+        ;
     }
 
     @Test
@@ -97,7 +100,8 @@ public class ProfileControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.code").value(HttpStatus.UNAUTHORIZED.value()))
                 .andExpect(jsonPath("$.name").value(HttpStatus.UNAUTHORIZED.getReasonPhrase()))
-                .andExpect(jsonPath("$.description").exists());;
+                .andExpect(jsonPath("$.description").exists());
+        ;
     }
 
 }

--- a/ms-customers/src/test/java/com/bankcore/customers/repository/UserRepositoryTest.java
+++ b/ms-customers/src/test/java/com/bankcore/customers/repository/UserRepositoryTest.java
@@ -20,16 +20,15 @@ class UserRepositoryTest extends AbstractIntegrationTest {
     UserRepository userRepository;
 
     @Test
-    void shouldFindByEmail() {
+    void shouldFindById() {
         UserEntity user1 = DataProvider.createMockUser();
 
-       userRepository.save(user1);
+       UserEntity savedUser = userRepository.save(user1);
 
-       Optional<UserEntity> found = userRepository.findByEmail("juan@test.com");
-
+       Optional<UserEntity> found = userRepository.findById(savedUser.getId());
 
         assertTrue(found.isPresent());
-        assertEquals(found.get(), user1);
+        assertEquals(found.get(), savedUser);
 
     }
 

--- a/ms-customers/src/test/java/com/bankcore/customers/service/UserManagementImplTest.java
+++ b/ms-customers/src/test/java/com/bankcore/customers/service/UserManagementImplTest.java
@@ -120,9 +120,9 @@ class UserManagementImplTest {
     void shouldReturnProfileWhenUserExists() {
 
         UserEntity user = DataProvider.createMockUser();
-        String email = user.getEmail();
+        UUID id = UUID.randomUUID();
         UserProfileResponse response = UserProfileResponse.builder()
-                .id(UUID.randomUUID().toString())
+                .id(id.toString())
                 .dni(user.getDni())
                 .firstName(user.getFirstName())
                 .lastName(user.getLastName())
@@ -133,30 +133,31 @@ class UserManagementImplTest {
                 .createdAt(user.getCreatedDate().toString())
                 .build();
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findById(id)).thenReturn(Optional.of(user));
         when(userMapper.toUserProfileResponse(user)).thenReturn(response);
 
-        UserProfileResponse result = userManagement.getCurrentUserProfile(email);
+        UserProfileResponse result = userManagement.getCurrentUserProfile(id.toString());
 
         assertEquals(response, result);
-        verify(userRepository).findByEmail(email);
+        verify(userRepository).findById(id);
         verify(userMapper).toUserProfileResponse(user);
 
     }
 
     @Test
-    void shouldThrowWhenEmailIsNull() {
+    void shouldThrowWhenIdIsNull() {
         assertThrows(IllegalArgumentException.class, () -> userManagement.getCurrentUserProfile(null));
     }
 
     @Test
-    void shouldThrowWhenEmailIsBlank() {
+    void shouldThrowWhenIdIsBlank() {
         assertThrows(IllegalArgumentException.class, () -> userManagement.getCurrentUserProfile(""));
     }
 
     @Test
     void shouldThrowWhenUserNotFound() {
-        when(userRepository.findByEmail("x")).thenReturn(Optional.empty());
-        assertThrows(UserProfileNotFoundException.class, () -> userManagement.getCurrentUserProfile("x"));
+        UUID id = UUID.randomUUID();
+        when(userRepository.findById(id)).thenReturn(Optional.empty());
+        assertThrows(UserProfileNotFoundException.class, () -> userManagement.getCurrentUserProfile(id.toString()));
     }
 }


### PR DESCRIPTION
## Cambiar JWT principal de email a UUID para consultar perfil del cliente autenticado

### Razón:

- El email es mutable y no debería ser usado como un identificador técnico 
- El UUID es estable y más adecuado para comunicación entre servicios